### PR TITLE
Set default data directory according to XDG directory specs and add archlinux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The information on this page is focused on the script itself. More information a
 
 Download the script and make it executable with the command `chmod a+x spn.sh`. The script can be run directly and does not need to be compiled to a binary executable beforehand.
 
+#### Arch Linux
+
+This script is also available as an [AUR package](https://aur.archlinux.org/packages/wayback-spn-script-git) and you can install it with your favorite AUR helper
+
+```bash
+yay -S wayback-spn-script-git
+```
+
 ### Dependencies
 
 This script is written in Bash and has been tested using the shell environment preinstalled binaries on macOS 10.14, macOS 12 and Windows 10 WSL Ubuntu. As far as possible, utilities have been used in ways in which behavior is consistent for both their GNU and BSD implementations. (The use of `sed -E` in particular may be a problem for older versions of GNU `sed`, but otherwise there should be no major compatibility issues.)

--- a/spn.sh
+++ b/spn.sh
@@ -178,9 +178,15 @@ Using existing data folder: $dir
 	done
 else
 	f=''
-	# Use XDG directory specification, if variable is not set default to ~/.local/share/spn-data
 	# Setting base directory on parent variable allows discarding redundant '~/' expansions
-	parent="${XDG_DATA_HOME:-$HOME\/.local\/share}/spn-data"
+	if [ "$(uname)" == "Darwin" ]; then
+		# Mac OS X platform
+		parent="${HOME}/Library/spn-data"
+	else
+		# Use XDG directory specification, if variable is not set default to ~/.local/share/spn-data
+		parent="${XDG_DATA_HOME:-$HOME\/.local\/share}/spn-data"
+	fi
+
 	month=$(date -u +%Y-%m)
 	now=$(date +%s)
 

--- a/spn.sh
+++ b/spn.sh
@@ -184,7 +184,11 @@ else
 		parent="${HOME}/Library/spn-data"
 	else
 		# Use XDG directory specification, if variable is not set default to ~/.local/share/spn-data
-		parent="${XDG_DATA_HOME:-$HOME\/.local\/share}/spn-data"
+		parent="${XDG_DATA_HOME:-$HOME/.local/share}/spn-data"
+		# if ~/.local/share doesn't exist use ~/spn-data
+		if [[ ! -d "$HOME/.local/share" ]]; then
+			parent="${HOME}/spn-data"
+		fi
 	fi
 
 	month=$(date -u +%Y-%m)

--- a/spn.sh
+++ b/spn.sh
@@ -3,19 +3,11 @@
 trap "abort" SIGINT SIGTERM
 
 function abort(){
-	if [[ -n "$custom_dir" ]]; then
-		echo "
+	echo "
 
 == Aborting spn.sh ==
 Data folder: $dir
 "
-	else
-		echo "
-
-== Aborting spn.sh ==
-Data folder: ~/$dir
-"
-	fi
 	exit 1
 }
 
@@ -186,13 +178,15 @@ Using existing data folder: $dir
 	done
 else
 	f=''
-	parent="spn-data"
+	# Use XDG directory specification, if variable is not set default to ~/.local/share/spn-data
+	# Setting base directory on parent variable allows discarding redundant '~/' expansions
+	parent="${XDG_DATA_HOME:-$HOME\/.local\/share}/spn-data"
 	month=$(date -u +%Y-%m)
 	now=$(date +%s)
 
 	for i in "$parent" "$parent/$month"; do
-		if [[ ! -d ~/"$i" ]]; then
-			mkdir ~/"$i" || { echo "The folder ~/$i could not be created"; exit 1; }
+		if [[ ! -d "$i" ]]; then
+			mkdir "$i" || { echo "The folder $i could not be created"; exit 1; }
 		fi
 	done
 
@@ -200,20 +194,20 @@ else
 	sleep ".0$((RANDOM % 8))"
 
 	# Wait between 0.1 and 0.73 seconds if the folder already exists
-	while [[ -d ~/"$parent/$month/$now$dir_suffix" ]]; do
+	while [[ -d "$parent/$month/$now$dir_suffix" ]]; do
 		sleep ".$((10 + RANDOM % 64))"
 		now=$(date +%s)
 	done
 	dir="$parent/$month/$now$dir_suffix"
 
 	# Try to create the folder
-	mkdir ~/"$dir" || { echo "The folder ~/$dir could not be created"; exit 1; }
+	mkdir "$dir" || { echo "The folder $dir could not be created"; exit 1; }
 	echo "
 
 == Starting spn.sh ==
-Data folder: ~/$dir
+Data folder: $dir
 "
-	cd ~/"$dir"
+	cd "$dir"
 fi
 
 # Convert links to HTTPS
@@ -725,6 +719,6 @@ else
 	echo "
 
 == Ending spn.sh ==
-Data folder: ~/$dir
+Data folder: $dir
 "
 fi


### PR DESCRIPTION
The script in this current version will try to put data under ~/spn-data by default
With this change, however, it will try to read XDG_DATA_HOME variable and if it cannot find the variable will default to $HOME/.local/share/