### PR TITLE
Dedupe `$list` variable alongside `index.txt`

### DIFF
--- a/spn.sh
+++ b/spn.sh
@@ -252,7 +252,8 @@ if [[ -n "$success" ]]; then
 	echo "$success" >> index.txt
 	echo "$success" >> success.log
 fi
-echo "$list" | awk '!seen [$0]++' >> index.txt
+# Dedupe list, then send to index.txt
+list=$(awk '!seen [$0]++' <<< "$list") && echo "$list" >> index.txt
 if [[ -n "$outlinks" ]]; then
 	touch outlinks.txt
 	# Create both files even if one of them would be empty


### PR DESCRIPTION
This PR fixes issue #36: Initial URLs aren't de-duplicated.

Since `index.txt` is deduped when starting the script and can be used later when resuming, it also makes sense to dedupe the `$file` variable when initializing.