### PR TITLE
Fix unwanted `grep` warnings

### DIFF
--- a/spn.sh
+++ b/spn.sh
@@ -408,7 +408,7 @@ function capture(){
 			echo "        $message"
 			
 			# Extract the delay, if any, from the message
-			delay=$(echo "$message" | grep -Po 'capture will start in (?:.*? hours?(?:,? *? minutes?)?(?:,? *? seconds?)?|.*? minutes?(?:,? *? seconds?)?|.*? seconds?)')
+			delay=$(echo "$message" | grep -Eo 'capture will start in (?:.*? hours?(?:,? *? minutes?)?(?:,? *? seconds?)?|.*? minutes?(?:,? *? seconds?)?|.*? seconds?)')
 			if [[ -n "$delay" ]]; then
 				delay_hours=$(echo "$delay" | sed -Ee 's/.* ~?([0-9]+) hours?.*/\1/g')
 				delay_minutes=$(echo "$delay" | sed -Ee 's/.* ~?([0-9]+) minutes?.*/\1/g')

--- a/spn.sh
+++ b/spn.sh
@@ -408,11 +408,11 @@ function capture(){
 			echo "        $message"
 			
 			# Extract the delay, if any, from the message
-			delay=$(echo "$message" | grep -Eo 'capture will start in (?:.*? hours?(?:,? *? minutes?)?(?:,? *? seconds?)?|.*? minutes?(?:,? *? seconds?)?|.*? seconds?)')
+			delay=$(echo "$message" | grep -Eo 'capture will start in')
 			if [[ -n "$delay" ]]; then
-				delay_hours=$(echo "$delay" | sed -Ee 's/.* ~?([0-9]+) hours?.*/\1/g')
-				delay_minutes=$(echo "$delay" | sed -Ee 's/.* ~?([0-9]+) minutes?.*/\1/g')
-				delay_seconds=$(echo "$delay" | sed -Ee 's/.* ~?([0-9]+) seconds?.*/\1/g')
+				delay_hours=$(echo "$message" | grep -Eo "[0-9]+ hour" | grep -Eo "[0-9]*")
+				delay_minutes=$(echo "$message" | grep -Eo "[0-9]+ minute" | grep -Eo "[0-9]*")
+				delay_seconds=$(echo "$message" | grep -Eo "[0-9]+ second" | grep -Eo "[0-9]*")
 				
 				# If the values are not integers, set them to 0
 				[[ $delay_hours =~ ^[0-9]+$ ]] || delay_hours="0"

--- a/spn.sh
+++ b/spn.sh
@@ -408,7 +408,7 @@ function capture(){
 			echo "        $message"
 			
 			# Extract the delay, if any, from the message
-			delay=$(echo "$message" | grep -Eo 'capture will start in (?:.*? hours?(?:,? *? minutes?)?(?:,? *? seconds?)?|.*? minutes?(?:,? *? seconds?)?|.*? seconds?)')
+			delay=$(echo "$message" | grep -Po 'capture will start in (?:.*? hours?(?:,? *? minutes?)?(?:,? *? seconds?)?|.*? minutes?(?:,? *? seconds?)?|.*? seconds?)')
 			if [[ -n "$delay" ]]; then
 				delay_hours=$(echo "$delay" | sed -Ee 's/.* ~?([0-9]+) hours?.*/\1/g')
 				delay_minutes=$(echo "$delay" | sed -Ee 's/.* ~?([0-9]+) minutes?.*/\1/g')


### PR DESCRIPTION
Fix #29: Remove unwanted `grep` warnings. 

These `grep` warnings are due to the `?` in the regular expression being interpreted as a quantifier in some cases, rather than as part of a non-greedy match. To avoid these warnings, we can use the `-P` option in `grep` to enable [Perl Compatible Regular Expressions](https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions) (PCRE).
